### PR TITLE
Reenable numpy 1.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   md5: ef96a766392617d976745a2ca4856a8b
 
 build:
-  number: 2
+  number: 3
   script:
     - python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
   osx_is_app: True
-  skip: True        # [py2k or win and np!=111]
+  skip: True        # [py2k]
 
 requirements:
   build:


### PR DESCRIPTION
Support was removed as scikit-learn did not provide builds for numpy
1.10. Maybe it does now?