### PR TITLE
Add keyring to dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,13 @@ requirements:
     - pyqt            4.11.*
     - pyqtgraph
     - joblib
+    - keyring
+    - keyrings.alt
     - python.app    # [osx]
 
 test:
   commands:
+    - python -c "import pkg_resources; pkg_resources.require('Orange3')"
     - orange-canvas --help
   imports:
     - Orange


### PR DESCRIPTION
Conda does not automatically install requirements listed in setup.py and widget discovery does not work if one of the requirements is missing.