### PR TITLE
Constrain python-louvain >=0.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
@@ -48,7 +48,7 @@ requirements:
     - pip >=9.0
     - python.app  # [osx]
     - serverfiles
-    - python-louvain
+    - python-louvain >=0.13
     - requests
     - matplotlib >=2.0.0
     - openTSNE >=0.3.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
It needs python-louvain >=0.13

Undeclared in its install_requires, but this is necessary as it uses the `random_seed` parameter introduced 0.13. 

<!--
Please add any other relevant info below:
-->
