### PR TITLE
Remove pin_compatible for numpy

### DIFF
--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -12,8 +12,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-numpy:
-- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -12,8 +12,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-numpy:
-- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - pip
     - wheel
-    - numpy >=1.16.0
+    - numpy 1.14
   run:
     - python
     - setuptools >=36.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
@@ -30,7 +30,7 @@ requirements:
   run:
     - python
     - setuptools >=36.3
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.16.0
     - scipy >=0.16.1
     - scikit-learn >=0.20.0
     - bottleneck >=1.0.0


### PR DESCRIPTION
Current package requires 1.17, which breaks the installer (forces 1.16).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
