### PR TITLE
Enable windows tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: bc9a9e200e28e8c03027d22d6a93ee9b097c3cd0a2cc50b01eca2df03a3ee32f
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - orange-canvas = Orange.canvas.__main__:main
   osx_is_app: true
@@ -58,7 +58,7 @@ requirements:
     - networkx
     - numpy >=1.20.0,<2
     - openpyxl >=3.1.3
-    - opentsne >=0.6.1,!=0.7.0
+    - opentsne >=0.6.1,!=0.7.0,!=1.0.2
     - packaging
     - pandas >=1.4.0,!=1.5.0,!=2.0.0
     - pip >=19.3
@@ -82,8 +82,7 @@ test:
     - orange-canvas --help
     - export QT_QPA_PLATFORM=offscreen  # [not win]
     # for now, only test on Windows (better have some tests than none)
-    # temporarily skipped; try again when pythoneditor tests pass on Orange's CI
-    # - python -m unittest -v Orange.tests Orange.widgets.tests  # [win]
+    - python -m unittest -v Orange.tests Orange.widgets.tests  # [win]
   requires:
     - pip
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Enable Windows tests. This skip openTSNE 1.0.2, because it segfaults in Orange.tests.test_manifold. I saw the same failures here yesterday, see https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1082873&view=results